### PR TITLE
remove small allocation from crossmatch()

### DIFF
--- a/crossmatch.c
+++ b/crossmatch.c
@@ -878,14 +878,12 @@ crossmatch(CrossmatchContext *ctx, ItemPointer values)
 	/* Return next result pair if any. Otherwise close SRF. */
 	if (ctx->resultsPairs != NIL)
 	{
-		ResultPair *itemPointerPair = (ResultPair *) palloc(sizeof(ResultPair));
-
-		*itemPointerPair = *((ResultPair *) linitial(ctx->resultsPairs));
+		ResultPair itemPointerPair = *((ResultPair *) linitial(ctx->resultsPairs));
 		pfree(linitial(ctx->resultsPairs));
 		ctx->resultsPairs = list_delete_first(ctx->resultsPairs);
 
-		values[0] = itemPointerPair->iptr1;
-		values[1] = itemPointerPair->iptr2;
+		values[0] = itemPointerPair.iptr1;
+		values[1] = itemPointerPair.iptr2;
 	}
 	else
 	{


### PR DESCRIPTION
I think this small allocation is not that necessary.

Also, there are calls to pfree() before list_delete_first() with same ptr. Is this common idiom? This may cause race condition inside allocator, but here it is safe, probably.