### PR TITLE
Set temporary tuple flag in tuple table slot

### DIFF
--- a/init.c
+++ b/init.c
@@ -644,7 +644,7 @@ fetch_next_pair(CrossmatchScanState *scan_state)
 		htup = heap_form_tuple(tupdesc, values, nulls);
 
 		/* Fill scanSlot with a new tuple */
-		ExecStoreTuple(htup, slot, InvalidBuffer, false);
+		ExecStoreTuple(htup, slot, InvalidBuffer, true);
 	}
 
 	if (buf1 != InvalidBuffer)


### PR DESCRIPTION
Hi! Here's one more memory leak. Though, I'm not that certain it's a bug.